### PR TITLE
fix(EC-1866): replace gh repo sync with merge-based upstream sync

### DIFF
--- a/.github/workflows/repo-sync.yaml
+++ b/.github/workflows/repo-sync.yaml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: repo-sync
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -95,6 +95,12 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           CONFLICTS=$(cat /tmp/conflicts.txt 2>/dev/null || echo "Could not determine conflicting files.")
+
+          EXISTING=$(gh issue list --state open --search "Upstream sync: manual merge needed" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Open sync issue already exists: #$EXISTING — skipping creation."
+            exit 0
+          fi
 
           gh issue create \
             --title "Upstream sync: manual merge needed ($(date +%Y-%m-%d))" \

--- a/.github/workflows/repo-sync.yaml
+++ b/.github/workflows/repo-sync.yaml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          ref: main
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Configure git
@@ -64,7 +66,7 @@ jobs:
           else
             echo "conflict=true" >> "$GITHUB_OUTPUT"
             git diff --name-only --diff-filter=U > /tmp/conflicts.txt 2>/dev/null || true
-            git merge --abort
+            git merge --abort || true
           fi
 
       - name: Push branch
@@ -84,7 +86,7 @@ jobs:
             --head "${{ steps.merge.outputs.branch }}" \
             --base main)
 
-          gh pr merge "$PR_URL" --auto --squash --delete-branch \
+          gh pr merge "$PR_URL" --auto --merge --delete-branch \
             || echo "::warning::Auto-merge could not be enabled. Merge the PR manually."
 
       - name: Create conflict issue

--- a/.github/workflows/repo-sync.yaml
+++ b/.github/workflows/repo-sync.yaml
@@ -6,8 +6,14 @@ on:
   schedule:
     - cron: "30 8 * * 1"
 
+concurrency:
+  group: repo-sync
+  cancel-in-progress: true
+
 permissions:
   contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   repo-sync:
@@ -19,8 +25,88 @@ jobs:
           app-id: ${{ vars.EC_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.EC_AUTOMATION_KEY }}
 
-      - run: gh repo sync $REPO
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "ec-automation[bot]"
+          git config user.email "ec-automation[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/google/go-containerregistry.git
+          git fetch upstream main
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git merge-base --is-ancestor upstream/main HEAD; then
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+            echo "Fork is already up to date with upstream."
+          else
+            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Attempt merge
+        if: steps.check.outputs.up_to_date == 'false'
+        id: merge
+        run: |
+          BRANCH="sync/upstream-$(date +%Y-%m-%d)-${GITHUB_RUN_NUMBER}"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+          git checkout -b "$BRANCH"
+
+          if git merge upstream/main --no-edit; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            git diff --name-only --diff-filter=U > /tmp/conflicts.txt 2>/dev/null || true
+            git merge --abort
+          fi
+
+      - name: Push branch
+        if: steps.check.outputs.up_to_date == 'false' && steps.merge.outputs.conflict == 'false'
+        run: git push origin "${{ steps.merge.outputs.branch }}"
+
+      - name: Open PR (clean merge)
+        if: steps.check.outputs.up_to_date == 'false' && steps.merge.outputs.conflict == 'false'
         env:
-          REPO: ${{ github.repository }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          GH_DEBUG: "1"
+        run: |
+          PR_URL=$(gh pr create \
+            --title "chore: sync with upstream google/go-containerregistry" \
+            --body "Automated weekly sync from [google/go-containerregistry](https://github.com/google/go-containerregistry).
+
+          Merge completed cleanly — no conflicts detected." \
+            --head "${{ steps.merge.outputs.branch }}" \
+            --base main)
+
+          gh pr merge "$PR_URL" --auto --squash --delete-branch \
+            || echo "::warning::Auto-merge could not be enabled. Merge the PR manually."
+
+      - name: Create conflict issue
+        if: steps.check.outputs.up_to_date == 'false' && steps.merge.outputs.conflict == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          CONFLICTS=$(cat /tmp/conflicts.txt 2>/dev/null || echo "Could not determine conflicting files.")
+
+          gh issue create \
+            --title "Upstream sync: manual merge needed ($(date +%Y-%m-%d))" \
+            --body "The weekly sync from [google/go-containerregistry](https://github.com/google/go-containerregistry) has conflicts that need manual resolution.
+
+          **Conflicting files:**
+
+          \`\`\`
+          $CONFLICTS
+          \`\`\`
+
+          To resolve:
+          1. \`git fetch upstream main\`
+          2. \`git checkout -b sync/upstream-fix\`
+          3. \`git merge upstream/main\`
+          4. Resolve conflicts and push
+          5. Open a PR to main"


### PR DESCRIPTION
## Summary

- Replace broken `gh repo sync` (fast-forward only) with a merge-based upstream sync workflow
- The old workflow broke Nov 2025 when the fork diverged and was disabled by GitHub for inactivity
- New workflow handles both clean merges (auto-PR + auto-merge) and conflicts (creates issue with resolution instructions)

## Changes

- **Up-to-date check**: skips entirely if fork already contains upstream/main
- **Clean merge path**: creates a PR and enables auto-merge
- **Conflict path**: aborts merge, captures conflicting file list, opens a GitHub issue with instructions
- **Concurrency guard**: prevents parallel run races
- **Unique branch names**: `sync/upstream-YYYY-MM-DD-RUN_NUMBER` handles same-day re-runs

## Test plan

- [ ] Trigger via `workflow_dispatch` after merging PR #4 (upstream sync)
- [ ] Verify clean merge produces a PR with auto-merge enabled
- [ ] Verify no-op when fork is already up to date
- [ ] Conflict path can be tested by cherry-picking a commit that modifies a file also changed upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)