### PR TITLE
fix: remove persist-credentials to allow repo-sync push

### DIFF
--- a/.github/workflows/repo-sync.yaml
+++ b/.github/workflows/repo-sync.yaml
@@ -29,7 +29,6 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
           ref: main
-          persist-credentials: false
           fetch-depth: 0
 
       - name: Configure git


### PR DESCRIPTION
## Summary

The `persist-credentials: false` added in PR #5 prevents `git push` from authenticating — the checkout action doesn't store the token in `.git/config`, so the push step fails with `could not read Username`.

The app token is already scoped and short-lived, so persisting it for the job duration is safe and necessary.

Discovered via manual `workflow_dispatch` run: https://github.com/conforma/go-containerregistry/actions/runs/28171774706

## Test plan

- [ ] Trigger `workflow_dispatch` on repo-sync after merging — push step should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)