### PR TITLE
fix: treat .local domains as local (use HTTP instead of HTTPS)

### DIFF
--- a/pkg/name/registry.go
+++ b/pkg/name/registry.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Detect more complex forms of localhost references.
-var reLocal = regexp.MustCompile(`.*\.localhost(?::\d{1,5})?$`)
+var reLocal = regexp.MustCompile(`.*\.local(?:host)?(?::\d{1,5})?$`)
 
 // Detect the loopback IP (127.0.0.1)
 var reLoopback = regexp.MustCompile(`^127\.0\.0\.1(?::\d{1,5})?$`)

--- a/pkg/name/registry_test.go
+++ b/pkg/name/registry_test.go
@@ -205,10 +205,10 @@ func TestRegistryScheme(t *testing.T) {
 		scheme: "http",
 	}, {
 		domain: "foo.svc.local:1234",
-		scheme: "https",
+		scheme: "http",
 	}, {
 		domain: "registry.local",
-		scheme: "https",
+		scheme: "http",
 	}, {
 		domain: "127.0.0.1:1234",
 		scheme: "http",


### PR DESCRIPTION
Extend the reLocal regex to match *.local in addition to *.localhost, so that .local registries default to HTTP.

The Conforma CLI acceptance tests use a local registry that does not support TLS. Without this change, go-containerregistry attempts HTTPS connections to *.local registries, causing those tests to fail. We may add TLS to the acceptance-test cluster in the future, but for now let's do this to get the tests passing again.

See also commit 2d863018 where the regex was changed 8 weeks ago.

See also https://redhat.atlassian.net/browse/EC-1866