### PR TITLE
fix: use GITHUB_TOKEN for PR/issue creation on fork

### DIFF
--- a/.github/workflows/repo-sync.yaml
+++ b/.github/workflows/repo-sync.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Open PR (clean merge)
         if: steps.check.outputs.up_to_date == 'false' && steps.merge.outputs.conflict == 'false'
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           PR_URL=$(gh pr create \
             --title "chore: sync with upstream google/go-containerregistry" \
@@ -91,7 +91,7 @@ jobs:
       - name: Create conflict issue
         if: steps.check.outputs.up_to_date == 'false' && steps.merge.outputs.conflict == 'true'
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           CONFLICTS=$(cat /tmp/conflicts.txt 2>/dev/null || echo "Could not determine conflicting files.")
 


### PR DESCRIPTION
## Summary

GitHub App installation tokens cannot create pull requests on forked repositories (GraphQL `createPullRequest` returns `Resource not accessible by integration`). This is a GitHub platform restriction for forks.

Switch the PR and issue creation steps to use `github.token` (the default `GITHUB_TOKEN`) which has `pull-requests: write` and `issues: write` from the workflow's permissions block. The App token is still used for checkout and `git push` (needs `contents: write`).

Discovered via manual `workflow_dispatch` run: https://github.com/conforma/go-containerregistry/actions/runs/28376204773

## Test plan

- [ ] Trigger `workflow_dispatch` on repo-sync after merging — PR creation should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)